### PR TITLE
Polymorphic functions and HList map

### DIFF
--- a/hlist.idr
+++ b/hlist.idr
@@ -1,10 +1,11 @@
+module HList
 import Data.Fin
 % default total
-namespace HList
-  infixr 7 ::
-  data HList : List Type -> Type where
-    HNil : HList []
-    (::) : t -> HList ts -> HList (t :: ts)
+
+infixr 7 ::
+data HList : List Type -> Type where
+  Nil : HList []
+  (::) : t -> HList ts -> HList (t :: ts)
   
 hcons :  t  -> HList ts -> HList (t :: ts)
 hcons x xs = x :: xs
@@ -14,11 +15,35 @@ pTakeEmpty Z = Refl
 pTakeEmpty (S m) = Refl
 
 take : (n: Nat) -> HList ts -> HList (take n ts)
-take n HNil = rewrite pTakeEmpty n {a = Type} in HNil
-take Z xs = HNil
+take n Nil = rewrite pTakeEmpty n {a = Type} in Nil
+take Z xs = Nil
 take (S m) (x :: xs) = x :: (take m xs)
 
 take' : (n: Nat) -> HList ts -> {auto p : n `lte` (length ts) = True} -> HList (take n ts)
-take' Z _ = HNil
-take' (S m) HNil = HNil -- impossible, but not proven to be so
+take' Z _ = Nil
+take' (S m) Nil = Nil -- impossible, but not proven to be so
 take' (S m) (x :: xs) = x :: (take m xs)
+
+infixr 0 ~~>
+data (~~>) : (Type -> Type) -> (Type -> Type) -> Type where
+  MkPoly : ((a: Type) -> (f a -> g a)) -> f ~~> g
+
+applyPoly: {a: Type} -> (f ~~> g) -> f a -> g a
+applyPoly {a = a} (MkPoly f) = (\fa => f a fa)
+
+data Mapper : ply -> List Type -> List Type -> Type where
+  NilMapper : Mapper (f ~~> g) [] []
+  ConsMapper : Mapper (f ~~> g) ts ts' -> Mapper (f ~~> g) ((f a) :: ts) ((g a) :: ts')
+
+listIntBoolMaybePrf : Mapper (List ~~> Maybe) [List Int, List Bool] [Maybe Int, Maybe Bool]
+listIntBoolMaybePrf = ConsMapper (ConsMapper NilMapper)
+
+maybeIntBoolMaybePrf : Mapper (Maybe ~~> Maybe) [Maybe Int, Maybe Bool] [Maybe Int, Maybe Bool]
+maybeIntBoolMaybePrf = ConsMapper (ConsMapper NilMapper)
+
+map' : (f ~~> g) -> HList ts -> Mapper (f ~~> g) ts ts' -> HList ts'
+map' _ _ NilMapper = Nil
+map' f (x :: xs) (ConsMapper y) = (applyPoly f x) :: (map' f xs y)
+
+map : (f ~~> g) -> HList ts -> {default tactics { search } prf : Mapper (f ~~> g) ts ts'} -> HList ts'
+map f xs {prf} = map' f xs prf


### PR DESCRIPTION
- Polymorphic functions are made by deferring the binding of a in a
  function of type f a -> g a. So it becomes (a: Type) -> f a -> g a.
- With these, we can map over HLists of types that share a common
  type constructor. I used proof search to automatically generate
  the output type of map.

Other changes:
- I changed the type constructors of HList to Nil and (::) so that
  we can use overloaded list syntax.
- I added some manually-rolled Mapper proofs that I used for debugging

Here's some example usage in the REPL:

``` Idris
*hlist> :let f: List ~~> Maybe;f = MkPoly (\a => head' {a = a})
*hlist> :let xs: HList[List Int, List Bool]; xs = [[2], [True]]
*hlist> map f xs
[Just 2, Just True] : HList [Maybe Int, Maybe Bool]

-- Id is a useful constructor
*hlist> :let Id: Type -> Type; Id a = a
*hlist> :let g: Id ~~> Maybe;g=MkPoly (\a => \_ => Nothing {a = a})
*hlist> [2, True]
Bool is not a numeric type
*hlist> map g [2, True]
[Nothing, Nothing] : HList [Maybe Integer, Maybe Bool]

-- We can even have polymorphic closures!
-- shapeless cannot do this
*hlist> :let indexer: Nat -> List ~~> Maybe;indexer n = MkPoly (\a => (\xs => index' n xs))
*hlist> :let ys: HList[List Int, List Bool]; ys = [[2], [True, False]]
*hlist> map (indexer 0) ys
[Just 2, Just True] : HList [Maybe Int, Maybe Bool]
*hlist> map (indexer 1) ys
[Nothing, Just False] : HList [Maybe Int, Maybe Bool]
*hlist> map (indexer 2) ys
[Nothing, Nothing] : HList [Maybe Int, Maybe Bool]
```
